### PR TITLE
Pin Pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "jupyterlab",
         "sklearn",
         "matplotlib",
-        "pandas",
+        "pandas<0.26.0,>=0.25.3",
         "pandas_market_calendars",
         "yahoofinancials",
         "cvxopt",


### PR DESCRIPTION
I had to pin pandas version, because some libraries were incompatible with pandas 1.0.0. Hence, the installation was failing.